### PR TITLE
 Resolving Bugfix: bug Same user can react same emoji multiple times …

### DIFF
--- a/apps/meteor/app/reactions/client/methods/setReaction.js
+++ b/apps/meteor/app/reactions/client/methods/setReaction.js
@@ -55,9 +55,11 @@ Meteor.methods({
 			if (!message.reactions[reaction]) {
 				message.reactions[reaction] = {
 					usernames: [],
+					userIdsAndNames: [],
 				};
 			}
 			message.reactions[reaction].usernames.push(user.username);
+			message.reactions[reaction].userIdsAndNames.push({ id: user._id, username: user.username });
 
 			Messages.update({ _id: messageId }, { $set: { reactions: message.reactions } });
 			callbacks.run('setReaction', messageId, reaction);

--- a/apps/meteor/client/components/message/content/Reactions.tsx
+++ b/apps/meteor/client/components/message/content/Reactions.tsx
@@ -24,7 +24,7 @@ const Reactions = ({ message }: ReactionsProps): ReactElement => {
 				Object.entries(message.reactions).map(([name, reactions]) => (
 					<Reaction
 						key={name}
-						counter={reactions.usernames.length}
+						counter={reactions.userIdsAndNames?.length}
 						hasReacted={hasReacted}
 						name={name}
 						names={filterReactions(name)}

--- a/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
+++ b/apps/meteor/client/views/room/MessageList/providers/MessageListProvider.tsx
@@ -53,29 +53,29 @@ const MessageListProvider: VFC<MessageListProviderProps> = ({ children }) => {
 				const { reactions } = message;
 				return !showRealName
 					? (reaction: string): string[] =>
-							reactions?.[reaction]?.usernames.filter((user) => user !== username).map((username) => `@${username}`) || []
+						reactions?.[reaction]?.userIdsAndNames?.filter((user) => user.id !== uid).map((user) => `@${user.username}`) || []
 					: (reaction: string): string[] => {
-							if (!reactions || !reactions[reaction]) {
-								return [];
-							}
-							if (!isMessageReactionsNormalized(message)) {
-								return message.reactions?.[reaction]?.usernames.filter((user) => user !== username).map((username) => `@${username}`) || [];
-							}
-							if (!username) {
-								return message.reactions[reaction].names;
-							}
-							const index = message.reactions[reaction].usernames.indexOf(username);
-							if (index === -1) {
-								return message.reactions[reaction].names;
-							}
+						if (!reactions || !reactions[reaction]) {
+							return [];
+						}
+						if (!isMessageReactionsNormalized(message)) {
+							return reactions?.[reaction]?.userIdsAndNames?.filter((user) => user.id !== uid).map((user) => `@${user.username}`) || []
+						}
+						if (!username) {
+							return message.reactions[reaction].names;
+						}
+						const index = message.reactions[reaction].usernames.indexOf(username);
+						if (index === -1) {
+							return message.reactions[reaction].names;
+						}
 
-							return message.reactions[reaction].names.splice(index, 1);
-					  };
+						return message.reactions[reaction].names.splice(index, 1);
+					};
 			},
 			useUserHasReacted: username
 				? (message) =>
-						(reaction): boolean =>
-							Boolean(message.reactions?.[reaction].usernames.includes(username))
+					(reaction): boolean =>
+						Boolean(message.reactions?.[reaction].userIdsAndNames?.filter((userIdAndName) => userIdAndName.id === uid).length > 0)
 				: () => (): boolean => false,
 			useShowFollowing: uid
 				? ({ message }): boolean => Boolean(message.replies && message.replies.indexOf(uid) > -1 && !isThreadMainMessage(message))
@@ -87,8 +87,8 @@ const MessageListProvider: VFC<MessageListProviderProps> = ({ children }) => {
 				: (): boolean => false,
 			useMessageDateFormatter:
 				() =>
-				(date: Date): string =>
-					date.toLocaleString(),
+					(date: Date): string =>
+						date.toLocaleString(),
 			showRoles,
 			showRealName,
 			showUsername,
@@ -108,13 +108,13 @@ const MessageListProvider: VFC<MessageListProviderProps> = ({ children }) => {
 
 			useOpenEmojiPicker: uid
 				? (message) =>
-						(e): void => {
-							e.nativeEvent.stopImmediatePropagation();
-							EmojiPicker.open(
-								e.currentTarget,
-								(emoji: string) => reactToMessage({ messageId: message._id, reaction: emoji }) as unknown as void,
-							);
-						}
+					(e): void => {
+						e.nativeEvent.stopImmediatePropagation();
+						EmojiPicker.open(
+							e.currentTarget,
+							(emoji: string) => reactToMessage({ messageId: message._id, reaction: emoji }) as unknown as void,
+						);
+					}
 				: () => (): void => undefined,
 		}),
 		[

--- a/packages/core-typings/src/IMessage/IMessage.ts
+++ b/packages/core-typings/src/IMessage/IMessage.ts
@@ -163,7 +163,12 @@ export interface IMessage extends IRocketChatRecord {
 	attachments?: MessageAttachment[];
 
 	reactions?: {
-		[key: string]: { names?: (string | undefined)[]; usernames: string[]; federationReactionEventIds?: Record<string, string> };
+		[key: string]: {
+			names?: (string | undefined)[];
+			usernames: string[];
+			federationReactionEventIds?: Record<string, string>;
+			userIdsAndNames: Record<string, string>;
+		};
 	};
 
 	private?: boolean;
@@ -244,6 +249,7 @@ export interface IMessageReactionsNormalized extends IMessage {
 		[key: string]: {
 			usernames: Required<IUser['_id']>[];
 			names: Required<IUser>['name'][];
+			userIdsAndNames: Record<string, string>;
 		};
 	};
 }


### PR DESCRIPTION
# CR: O mesmo usuário pode reagir com o mesmo emoji várias vezes


Link da CR: [Same user can react with the same emoji multiple times](https://github.com/upe-garanhuns/msw-alfa-2022/issues/7)
Link da CR Original: [RocketChat#6985](https://github.com/RocketChat/Rocket.Chat/issues/6985)

  * **Esforço total estimado para implementação**:
     * 10h
  * **Tempo total para implementação**:
     * 6h
  * **Lista de artefatos para alteração estimados pela análise:**
    *  Nova Migration na pasta apps/meteor/server/startup/migrations usando o script apps/meteor/.scripts/make-migration.ts
    * Modificação de propriedades no Arquivo setReaction
    * Criação de nova Migration para modificar a entidade message adicionando uma propriedade dos ids dos usuários que reagiram.
    * Modificar a interface/type "IMesage", na propriedade reactions para incluir novo campo com IDs dos usuários.
    * Modificar a propriedade "userAlreadyReacted" dos arquivos setReaction, para validar os IDs ao invés do userName.
    * Adicionar nos arquivos setReaction o userId após uma reação para ser usada nas validações futuras.
  * **Lista de artefatos alterados pela implementação:**
    * apps/meteor/app/reactions/client/methods/**setReaction.js**
    * apps/meteor/app/reactions/server/**setReaction.js**
    * apps/meteor/client/components/message/content/**Reactions.tsx**
    * apps/meteor/client/views/room/MessageList/providers/**MessageListProvider.tsx**
    * packages/core-typings/src/IMessage/I**Message.ts**
  * **Screenshot antes da implementação:** 
    * O comportamento atual do problema pode ser sintetizado em um bug relacionado às reações que o usuário pode submeter às mensagens. Ao reagir uma mensagem e, por ventura, o usuário chegar a mudar o seu Username (que é o seu nome de usuário), é possível reagir novamente a mesma mensagem, como se não o tivesse feito antes. Isso dá uma ideia de que o usuário criou um novo perfil, o que não é verdade, mas sim mudou uma instância do seu perfil. Então tal comportamento não é adequado.
    * ![image](https://user-images.githubusercontent.com/92036392/234154731-f60122ec-d5f9-46ee-8433-7f5614bff533.png)
    * ![image](https://user-images.githubusercontent.com/92036392/234154829-b922314a-e7b7-49b0-a7b7-699194069e94.png)
  * **Screenshot depois da implementação:** 
    * O comportamento que se espera ser atingido conta nos seguintes passos. Ao reagir uma mensagem, fica registrado no histórico de reações da mesma o nome do usuário que a curtiu e mesmo ao atualizar o seu userName para um antigo ou novo, ao verificar novamente o histórico de reações, a mesma constará uma reação já realizada, não permitindo assim que o usuário reaja novamente da mesma forma.
    * ![image](https://user-images.githubusercontent.com/92036392/234155114-6c3a6780-2f3a-49b9-9f33-20e8227f9242.png)
    *  ![image](https://user-images.githubusercontent.com/92036392/234154994-d4ea67ab-ef32-45d1-add9-5a713a1e3389.png)
  * **Passos para reproduzir e validar:**
    1. Reagir a uma mensagem
    2. Verificar o nome assinado ao usuário que reagiu a mensagem
    3. Mudar o nome do seu usuário
    4. Voltar ao chat onde houve a última reação
    5. Verificar o nome assinado ao usuário que reagiu a mensagem
    6. Reagir a imagem 

 

