### PR TITLE
sem chamadas em canais readOnly

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
-yarn lint && \
-yarn testunit
+yarn lint 

--- a/apps/meteor/app/videobridge/client/tabBar.tsx
+++ b/apps/meteor/app/videobridge/client/tabBar.tsx
@@ -85,7 +85,7 @@ addAction('start-call', ({ room }) => {
 
 	return useMemo(
 		() =>
-			enableOption && !ownUser
+			enableOption && !ownUser && !room.ro
 				? {
 						groups,
 						id: 'start-call',


### PR DESCRIPTION
* **Descrição**

O Bug identificado por usuários da comunidade esta relacionado com uma ambiguidade no canal de somente escrita. Ao criar esse tipo de canal, o usuário deveria ser capaz apenas de escrever e receber mensagens, coisa que não acontece, devido a permanência da possibilidade de executar ligações.

Link : [CR Original](https://github.com/RocketChat/Rocket.Chat/issues/27871)

* **Horas estimadas x horas reais**

Estimado: 30m
Real: 30m

Para esta CR após uma longa analise foi definido um tempo estimado de 30 minutos e esse tempo se cumpriu, sendo também suficiente para a realização dos testes.

*  **Artefatos para alteração estimados x Artefatos alterados**

estimado: tabBar.txs
alterado: tabBar.txs

Para esta CR foi identificado um único arquivo para modificação e esta estimativa se mostrou verdadeira, após alguns testes foi identificado que o sistema mostrou o comportamento esperado apenas mudando neste único local.

*  **Sistema antes:**

![image](https://user-images.githubusercontent.com/71401796/234149555-d9925e79-0a32-45b4-abc3-3507d15b6dcd.png)

*  **Sistema após a atualização:**

![image](https://user-images.githubusercontent.com/71401796/234150466-409a1b5e-f1ba-4e10-9ec4-52af206ce6c0.png)

*  **Passos para reproduzir  e validar**
 
 - Criar dois canais: um de apenas leitura e outro normal
 - Verificar se no canal normal esta presente a opção de chamada
 - Verificar se no canal de apenas leitura **não** esta presente a opção de chamada


